### PR TITLE
Added dynamic type params

### DIFF
--- a/dbcaml/param.ml
+++ b/dbcaml/param.ml
@@ -1,4 +1,8 @@
-type t = string
+type t =
+  | String of string
+  | Number of int
+  | Bool of bool
+  | Float of float
 
 let params params =
   match params with

--- a/dbcaml_driver_postgres/dbcaml_driver_postgres.ml
+++ b/dbcaml_driver_postgres/dbcaml_driver_postgres.ml
@@ -36,7 +36,16 @@ module Postgres = struct
         Dbcaml.ErrorMessages.result =
       try
         let array_params =
-          Array.of_list (List.map (fun x -> conn#escape_string x) params)
+          List.map
+            (fun x ->
+              match x with
+              | Dbcaml.Param.String s -> s
+              | Dbcaml.Param.Number i -> string_of_int i
+              | Dbcaml.Param.Float i -> string_of_float i
+              | Dbcaml.Param.Bool i -> string_of_bool i)
+            params
+          |> List.map (fun x -> conn#escape_string x)
+          |> Array.of_list
         in
         conn#send_query ~params:array_params query;
 

--- a/examples/basic_postgres/main.ml
+++ b/examples/basic_postgres/main.ml
@@ -19,7 +19,7 @@ let () =
   (match
      Dbcaml.Dbcaml.fetch_one
        conn
-       ~params:["1"]
+       ~params:[String "1"]
        "select * from users where id = $1"
    with
   | Ok x ->
@@ -38,7 +38,7 @@ let () =
   (match
      Dbcaml.Dbcaml.fetch_one
        conn
-       ~params:["1"]
+       ~params:[String "1"]
        "select * from users where ids = $1"
    with
   | Ok x ->


### PR DESCRIPTION
This PR adds dynamic typed params. The way you add a type to the param is by adding ex `String` before the value in the params list. Ex:

```
  Dbcaml.Dbcaml.fetch_one
       conn
       ~params:["1"]
       ~params:[String "1"]
       "select * from users where id = $1"
```