### PR TITLE
fix: don't use separate random library

### DIFF
--- a/dbcaml_driver_postgres/lib/dune
+++ b/dbcaml_driver_postgres/lib/dune
@@ -8,7 +8,6 @@
   messages
   bytestring
   str
-  random
   cryptokit
   mirage-crypto
   castore))

--- a/dbcaml_driver_postgres/lib/nonce.ml
+++ b/dbcaml_driver_postgres/lib/nonce.ml
@@ -1,10 +1,10 @@
 (** Generate a random nonce used for generating random statements and portals *)
 let generate () =
-  let count = Random.int ~max:(64 - 28 + 28) () in
+  let count = Random.int (64 - 28 + 28) in
 
   let gen_char () =
     let rec loop () =
-      let c = Random.int ~max:(0x7E - 0x21 + 1) () in
+      let c = Random.int (0x7E - 0x21 + 1) in
       if c = 0x2C then
         loop ()
       else
@@ -21,7 +21,7 @@ let random_string length =
   let result = Bytes.create length in
 
   for i = 0 to length - 1 do
-    Bytes.set result i chars.[Random.int ~max:chars_len ()]
+    Bytes.set result i chars.[Random.int chars_len]
   done;
 
   Bytes.to_string result


### PR DESCRIPTION
I was having some build problems with `random` and some of the other deps from riot. I was able to build after removing random and using Random from one of the other libs.