### PR TITLE
fix: remove version requirement from packages, testing with dune pkg lock

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -51,12 +51,13 @@
   dune
   (riot
    (>= 0.0.9))
-  (dbcaml :version)
   bytestring
   cryptokit
-  (serde-postgres :version)
   castore
-  uri)
+  uri
+  ;; Internal
+  dbcaml
+  serde-postgres)
  (tags
   (topics "database" "dbcaml" "dbcaml")))
 
@@ -70,7 +71,7 @@
   dune
   serde
   serde_derive
-  (serde-postgres :version))
+  serde-postgres)
  (tags
   (topics "postgres" "ocaml")))
 

--- a/dune.lock/lock.dune
+++ b/dune.lock/lock.dune
@@ -10,7 +10,7 @@
   ((source
     https://github.com/ocaml-dune/opam-overlays.git#9bad4501e6dd4feb7b61b48d29812241d1d711f9))
   ((source
-    https://github.com/ocaml/opam-repository.git#26c09ff1da6a07b20a0f9474e3a6ed6315c6388b))))
+    https://github.com/ocaml/opam-repository.git#cdc6ae9b86b5d59f665566d918bbf96a11804b7e))))
 
 (expanded_solver_variable_bindings
  (variable_values


### PR DESCRIPTION
Testing to see if this will fix the problem I'm having here for octane:

```
; dune build   
    Building dbcaml-driver-postgres.dev
Context: _private                    
File "dbcaml_driver_postgres/lib/dune", line 10, characters 2-16:
10 |   serde-postgres
       ^^^^^^^^^^^^^^
Error: Library "serde-postgres" not found.
-> required by library "dbcaml-driver-postgres" in
   _build/default/dbcaml_driver_postgres/lib
-> required by _build/default/META.dbcaml-driver-postgres
-> required by _build/install/default/lib/dbcaml-driver-postgres/META
-> required by _build/default/dbcaml-driver-postgres.install
-> required by alias install
File "dbcaml_driver_postgres/lib/messages/lib/dune", line 4, characters 17-23:
4 |  (libraries riot dbcaml))
                     ^^^^^^
Error: Library "dbcaml" not found.
-> required by library "messages" in
   _build/default/dbcaml_driver_postgres/lib/messages/lib
-> required by _build/default/META.dbcaml-driver-postgres
-> required by _build/install/default/lib/dbcaml-driver-postgres/META
-> required by _build/default/dbcaml-driver-postgres.install
-> required by alias install
```